### PR TITLE
Bump nginx to stable 1.20

### DIFF
--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -324,7 +324,7 @@ In the [`examples/rasa`](../../examples) directory you can find more detailed ex
 | nginx.customConfiguration | object | `{}` | Custom configuration for Nginx sidecar |
 | nginx.enabled | bool | `true` | Enabled Nginx as a sidecar container |
 | nginx.image.name | string | `"nginx"` | Image name to use |
-| nginx.image.tag | string | `"1.19"` | Image tag to use |
+| nginx.image.tag | string | `"1.20"` | Image tag to use |
 | nginx.livenessProbe | object | Every 15s / 6 KO / 1 OK | Override default liveness probe settings |
 | nginx.port | int | `80` | Port number that Nginx listen on |
 | nginx.readinessProbe | object | Every 15s / 6 KO / 1 OK | Override default readiness probe settings |

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -550,7 +550,7 @@ nginx:
     name: "nginx"
 
     # -- Image tag to use
-    tag: "1.19"
+    tag: "1.20"
 
   # -- Override default liveness probe settings
   # @default -- Every 15s / 6 KO / 1 OK


### PR DESCRIPTION
Bump nginx to the latest [stable version](https://nginx.org/en/download.html), v1.20.