### PR TITLE
Fix nil pointer error when upper level doesn't exist in .Values

### DIFF
--- a/charts/rasa-common/templates/_rabbitmq.tpl
+++ b/charts/rasa-common/templates/_rabbitmq.tpl
@@ -27,7 +27,7 @@ Return the rabbitmq password secret name.
 Return the rabbitmq port.
 */}}
 {{- define "rasa-common.rabbitmq.port" -}}
-{{- coalesce .Values.rabbitmq.service.port 5672 -}}
+{{- default 5672 ((.Values.rabbitmq).service).port -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Would fix #40