### PR TITLE
sync README.md to our webpage branch

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: |
+          cp -f README.md ${{ runner.temp }}/README.md
+
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - run: |
+          cp -f ${{ runner.temp }}/README.md .
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add README.md
+          git commit --signoff -m "Sync README from main"
+          git push

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ helm repo update
 
 ## How to contribute
 
-We are very happy to receive your contributions. You can
-find more information about how to contribute to Rasa (in lots of
-different ways!) [here](http://rasa.com/community/contribute).
+We are very happy to receive your contributions. You can find more information about how to contribute to Rasa (in lots of different ways!) [here](http://rasa.com/community/contribute).
 
 To contribute via pull request, follow these steps:
 


### PR DESCRIPTION
https://helm.rasa.com/ is empty.

To fix it, I'm bringing this workflow that has been used in other public chart repositories.

The index will be populated automatically with the content of the README.md