### PR TITLE
fix(rasa): Use alpine's wget instead of busybox to download

### DIFF
--- a/charts/rasa/templates/_load-initial-model.yaml
+++ b/charts/rasa/templates/_load-initial-model.yaml
@@ -1,6 +1,6 @@
 {{- define "rasa.downloadInitialModel.initContainer" -}}
 - name: download-initial-model
-  image: "busybox"
+  image: "alpine"
   command: ["/bin/sh", "-c"]
   args:
     - cd /app/models/ && wget {{ .Values.applicationSettings.initialModel }} -O model.tar.gz


### PR DESCRIPTION
As of Apr 16, 2022, `busybox` still hasn't updated `wget` to fix the issue with LetsEncrypt's new CA Certificate, giving this error:

```
Connecting to f003.backblazeb2.com (45.11.36.16:443)
wget: note: TLS certificate validation not implemented
wget: got bad TLS record (len:0) while expecting handshake record
wget: error getting response: Connection reset by peer
Error from server (BadRequest): container "rasa-oss" in pod "zasha-rasa-5fdb888b75-95vbh" is waiting to start: PodInitializing
```

This is easily solvable by using a modern wget instead, for example the one provided by `alpine`:

```
Connecting to f003.backblazeb2.com (45.11.36.16:443)
saving to '20220416-095509-emerald-birch.tar.gz'
20220416-095509-emer 100% |******************************************************| 23.9M  0:00:00 ETA
'20220416-095509-emerald-birch.tar.gz' saved
```