### PR TITLE
Fix type of nodePort field in JSON schema  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ charts/*/index.yaml
 
 # vscode local history extension
 .history
+
+# vscode local configurations
+.vscode

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.3
+version: 1.17.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -58,5 +58,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump Rasa to 3.2.6
+    - kind: fixed
+      description: Change type to integer for `nodePort` field in JSON schema.

--- a/charts/rasa/values.schema.json
+++ b/charts/rasa/values.schema.json
@@ -687,7 +687,7 @@
                     "type": "null"
                 },
                 "nodePort": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "port": {
                     "type": "integer"


### PR DESCRIPTION
Updated type of `nodePort` field from `null` to `integer` in JSON schema.