### PR TITLE
Pull 3rd party images from our artifact registry

### DIFF
--- a/.github/workflows/chart-readme.yml
+++ b/.github/workflows/chart-readme.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   render_readme:
     name: Render README.md
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
+env:
+  HELM_EXPERIMENTAL_OCI: '1'
+
 jobs:
   # JOB to run change detection
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
 
   install-chart:
     name: Install chart
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs:
       - lint-chart
       - kubeval-chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,10 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
-env:
-  HELM_EXPERIMENTAL_OCI: '1'
-
 jobs:
   # JOB to run change detection
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       # Expose matched filters as job 'charts' output variable
       charts: ${{ steps.changes.outputs.charts }}
@@ -52,7 +49,7 @@ jobs:
         fi
 
   lint-chart:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changes
     steps:
       - name: Checkout
@@ -63,7 +60,7 @@ jobs:
 
       - name: Set up Helm
         if: needs.changes.outputs.changed == 'true'
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.11.2
 
@@ -83,7 +80,7 @@ jobs:
         run: ct lint --config .github/.ct.yaml
 
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changes
     strategy:
       matrix:
@@ -115,7 +112,7 @@ jobs:
         run: go test -v
 
   kubeval-chart:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changes
     strategy:
       matrix:
@@ -130,9 +127,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.6.0
+          version: v3.11.2
 
       - name: Render template
         run: |
@@ -149,7 +146,7 @@ jobs:
 
   install-chart:
     name: Install chart
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - lint-chart
       - kubeval-chart
@@ -171,7 +168,7 @@ jobs:
           node_image: kindest/node:${{ matrix.k8s }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.11.2
 
@@ -204,7 +201,7 @@ jobs:
 
   validate:
     name: Validate the PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - unit-tests
       - kubeval-chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: needs.changes.outputs.changed == 'true'
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.0
+          version: v3.11.2
 
       # helm/chart-testing-action requires python version >= 3.7
       # see: https://github.com/helm/chart-testing-action/issues/65
@@ -170,7 +170,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.0
+          version: v3.11.2
 
       - name: Install chart
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+env:
+  HELM_EXPERIMENTAL_OCI: '1'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.0
+          version: v3.11.2
 
       - name: Helm dependency update
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-env:
-  HELM_EXPERIMENTAL_OCI: '1'
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@6135c0ff6214e01d42a5736c988e39b7831f1e2f #0.9.0
@@ -27,7 +25,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.11.2
 

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/update_app_version.yaml
+++ b/.github/workflows/update_app_version.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   open_pull_request:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/charts/rasa-action-server/Chart.lock
+++ b/charts/rasa-action-server/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm.rasa.com
   version: 1.0.2
 digest: sha256:2154e90d996acc784ae39b3780476a9eaa725197d793579f92e52312f9abd0d6
-generated: "2022-12-09T11:44:29.923703-05:00"
+generated: "2023-03-21T10:47:50.140514+01:00"

--- a/charts/rasa-action-server/Chart.yaml
+++ b/charts/rasa-action-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/rasa/Chart.lock
+++ b/charts/rasa/Chart.lock
@@ -3,13 +3,13 @@ dependencies:
   repository: https://helm.rasa.com
   version: 1.0.2
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   version: 10.16.2
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   version: 15.7.6
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   version: 8.32.2
 - name: rasa-action-server
   repository: https://helm.rasa.com

--- a/charts/rasa/Chart.lock
+++ b/charts/rasa/Chart.lock
@@ -13,9 +13,9 @@ dependencies:
   version: 8.32.2
 - name: rasa-action-server
   repository: https://helm.rasa.com
-  version: 1.0.4
+  version: 1.0.5
 - name: duckling
   repository: https://helm.rasa.com
   version: 1.1.4
-digest: sha256:cd37d2e7fee2710d5d1ad71479a8e9930bafe7bd8bfc775fcecb0130b1047a67
-generated: "2022-12-09T11:51:46.801117-05:00"
+digest: sha256:6fca88fb2f77f0c0483574aa26cc07b1d334cbe9326d34fbe201328e6bf254b2
+generated: "2023-03-21T10:46:45.216128+01:00"

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -37,15 +37,15 @@ dependencies:
     version: ~1.0.2
   - name: postgresql
     version: ~10.16.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: postgresql.install
   - name: redis
     version: ~15.7.6
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: redis.install
   - name: rabbitmq
     version: ~8.32.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: rabbitmq.install
   - name: rasa-action-server
     version: ~1.0.4

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -36,15 +36,15 @@ dependencies:
       - rasa-common
     version: ~1.0.2
   - name: postgresql
-    version: ~10.16.2
+    version: 10.16.2
     repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: postgresql.install
   - name: redis
-    version: ~15.7.6
+    version: 15.7.6
     repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: redis.install
   - name: rabbitmq
-    version: ~8.32.2
+    version: 8.32.2
     repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
     condition: rabbitmq.install
   - name: rasa-action-server

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.4
+version: 1.17.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
- Bitnami will soon stop supporting current versions
- Pull 3rd party images from our artifact registry instead of bitnami's