### PR TITLE
feat(hostAliases): enable configuring hostAliases in rasa components

### DIFF
--- a/charts/rasa-action-server/Chart.yaml
+++ b/charts/rasa-action-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/rasa-action-server/templates/deployment.yaml
+++ b/charts/rasa-action-server/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.hostAliases }}
+  hostAliases:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/charts/rasa-action-server/values.yaml
+++ b/charts/rasa-action-server/values.yaml
@@ -21,6 +21,12 @@ applicationSettings:
 # -- Specify the number of Action Server replicas
 replicaCount: 1
 
+# -- Specify the hostAliases of the Action Server pods
+hostAliases: []
+# - ip: 127.0.0.1
+#   hostnames:
+#     - "localhost"
+
 # -- Override the default arguments for the container
 args: []
 

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.6
+version: 1.17.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/rasa/templates/deployment.yaml
+++ b/charts/rasa/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.hostAliases }}
+  hostAliases:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -189,6 +189,12 @@ applicationSettings:
 # -- Specify the number of Rasa Open Source replicas
 replicaCount: 1
 
+# -- Specify the hostAliases of Rasa Open Source pods
+hostAliases: []
+# - ip: 127.0.0.1
+#   hostnames:
+#     - "localhost"
+
 networkPolicy:
   # -- Enable Kubernetes Network Policy
   enabled: false


### PR DESCRIPTION
This PR introduces the ability to configure `hostAliases` to rasa pods.

This will be useful in corporate environments where some services are behind private service endpoints provided by hyperscalers and accessible with private connectivity such as AWS Direct Link or Azure ExpressRoute.